### PR TITLE
Lower required netstandard version for Geography

### DIFF
--- a/Geography/Geography.csproj
+++ b/Geography/Geography.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <AssemblyName>Archon.Enums.Geography</AssemblyName>
     <RootNamespace>Archon.Enums</RootNamespace>
     <Product>Archon Framework Library™</Product>


### PR DESCRIPTION
It is only using things from netstandard 1.0. This allows more compatibility.

Followup for #4 